### PR TITLE
fix: correr migrations de alembic automaticamente en el startup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,14 +18,25 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from sqlalchemy import text
 
+from alembic.config import Config
+from alembic import command as alembic_command
+import os
 import config
 from database import db, get_engine
 from logging_config import setup_file_logger
 from middleware import LoggingMiddleware, ErrorHandlerMiddleware
-from routers import auth, catalogs, products, movements, users, purchases, proveedores, reports
+from routers import (
+    auth,
+    catalogs,
+    products,
+    movements,
+    users,
+    purchases,
+    proveedores,
+    reports,
+)
 from routers.movements import dashboard_router, importacion_router
 from tasks.backup import backup_database
-
 
 logger = setup_file_logger("autostock")
 
@@ -35,7 +46,7 @@ def seed_default_admin(conn) -> None:
     total_users = conn.execute(text("SELECT COUNT(*) FROM usuarios")).scalar_one()
     if total_users > 0:
         return
-    
+
     seed_default_catalog(conn)
 
     role_id = conn.execute(
@@ -59,12 +70,10 @@ def seed_default_admin(conn) -> None:
     ).decode("utf-8")
 
     conn.execute(
-        text(
-            """
+        text("""
             INSERT INTO usuarios (nombre, email, password_hash, role_id, bloqueado_hasta, activo, created_at)
             VALUES (:nombre, :email, :password_hash, :role_id, :bloqueado_hasta, :activo, :created_at)
-            """
-        ),
+            """),
         {
             "nombre": "Administrador",
             "email": "admin@autostock.local",
@@ -76,69 +85,69 @@ def seed_default_admin(conn) -> None:
         },
     )
 
+
 def seed_default_catalog(conn) -> None:
-    """ Insercion de unidades de medida, areas y categorías iniciales del sistema """
+    """Insercion de unidades de medida, areas y categorías iniciales del sistema"""
     unidades = [
         ("Kilogramo", "kg"),
         ("Litro", "L"),
         ("Mililitro", "mL"),
-        ("Pieza","PZA"),
+        ("Pieza", "PZA"),
         ("Unidad", "U"),
         ("Caja", "caja"),
         ("Paquete", "paq"),
         ("Gramo", "g"),
         ("Galón", "Gal"),
-        ("Docena","dz"),
+        ("Docena", "dz"),
         ("Bulto", ""),
     ]
-    
-    areas = ("Cocina", 
-             "Almacén general",
-             "Barra", 
-             "Área de limpieza",  
-             "Área administrativa",
-             "Área de mantenimiento",
+
+    areas = (
+        "Cocina",
+        "Almacén general",
+        "Barra",
+        "Área de limpieza",
+        "Área administrativa",
+        "Área de mantenimiento",
     )
-    
-    categorias = ("Productos de limpieza", 
-                  "Materias primas",
-                  "Bebidas",
-                  "Almacén general",
-                  "Equipo",
-                  "Utensilios",
-                  "Misceláneos",
+
+    categorias = (
+        "Productos de limpieza",
+        "Materias primas",
+        "Bebidas",
+        "Almacén general",
+        "Equipo",
+        "Utensilios",
+        "Misceláneos",
     )
-    
-    
+
     for nombre, abreviacion in unidades:
         conn.execute(
-            text("INSERT OR IGNORE INTO unidades_medida (nombre, abreviacion)"
-                 "VALUES (:nombre, :abreviacion)"
-                 ),
-            {"nombre":nombre, "abreviacion":abreviacion},
+            text(
+                "INSERT OR IGNORE INTO unidades_medida (nombre, abreviacion)"
+                "VALUES (:nombre, :abreviacion)"
+            ),
+            {"nombre": nombre, "abreviacion": abreviacion},
         )
-        
-        
+
     for nombre in areas:
         conn.execute(
-            text("INSERT OR IGNORE INTO areas (nombre)"
-                 "VALUES (:nombre)"
-                 ),
-            {"nombre":nombre},
+            text("INSERT OR IGNORE INTO areas (nombre)" "VALUES (:nombre)"),
+            {"nombre": nombre},
         )
-        
-        
+
     for nombre in categorias:
         conn.execute(
-            text("INSERT OR IGNORE INTO categorias (nombre)"
-                 "VALUES (:nombre)"
-                 ),
-            {"nombre":nombre}
+            text("INSERT OR IGNORE INTO categorias (nombre)" "VALUES (:nombre)"),
+            {"nombre": nombre},
         )
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    _alembic_cfg = Config(os.path.join(os.path.dirname(__file__), "alembic.ini"))
+    alembic_command.upgrade(_alembic_cfg, "head")
+
     mode = db.init_wal()
     logger.info(f"SQLite journal_mode = {mode}")
 
@@ -231,16 +240,16 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     )
 
 
-app.include_router(auth.router,      prefix="/api/auth",        tags=["auth"])
-app.include_router(catalogs.router,  prefix="/api/catalogos",   tags=["catalogos"])
-app.include_router(products.router,  prefix="/api/productos",   tags=["productos"])
+app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
+app.include_router(catalogs.router, prefix="/api/catalogos", tags=["catalogos"])
+app.include_router(products.router, prefix="/api/productos", tags=["productos"])
 app.include_router(movements.router, prefix="/api/movimientos", tags=["movimientos"])
-app.include_router(dashboard_router,    prefix="/api/dashboard",    tags=["dashboard"])
-app.include_router(importacion_router,  prefix="/api/importacion",  tags=["importacion"])
-app.include_router(users.router,     prefix="/api/usuarios",    tags=["usuarios"])
-app.include_router(purchases.router, prefix="/api/compras",     tags=["compras"])
+app.include_router(dashboard_router, prefix="/api/dashboard", tags=["dashboard"])
+app.include_router(importacion_router, prefix="/api/importacion", tags=["importacion"])
+app.include_router(users.router, prefix="/api/usuarios", tags=["usuarios"])
+app.include_router(purchases.router, prefix="/api/compras", tags=["compras"])
 app.include_router(proveedores.router, prefix="/api/proveedores", tags=["proveedores"])
-app.include_router(reports.router,   prefix="/api/reportes",    tags=["reportes"])
+app.include_router(reports.router, prefix="/api/reportes", tags=["reportes"])
 app.include_router(reports.admin_router, prefix="/api/admin", tags=["admin"])
 
 


### PR DESCRIPTION
Problema: Al clonar el repositorio y ejecutar el servidor por primera vez, las tablas de SQLite no existen. El servidor falla inmediatamente porque lifespan() intenta consultar la tabla usuarios antes de crearla. El startup no ejecutaba las migraciones de Alembic automáticamente. Se tenía que correr alembic upgrade head manualmente antes de iniciar el servidor.
 
Solución: Se agregó alembic upgrade head al inicio de lifespan() en main.py. En una base de datos nueva crea todas las tablas. En una existente detecta que ya está en head y no hace nada.