### PR TITLE
fix(inventario): corregir distribución de columnas y detección de duplicados en modal bulk-add

### DIFF
--- a/frontend/scripts/inventario.js
+++ b/frontend/scripts/inventario.js
@@ -428,6 +428,13 @@ function addProductRow(prefill) {
   tbody.appendChild(tr);
   _attachNameDebounce(tr);
 
+  // Si el nombre viene pre-rellenado (ej. al mover desde "existentes"),
+  // disparar 'input' para que el debounce verifique la coincidencia automáticamente.
+  if (prefill?.name) {
+    const nameInput = tr.querySelector('input[name="name"]');
+    if (nameInput) nameInput.dispatchEvent(new Event('input'));
+  }
+
   if (prefill?.name) {
     const clearItem = tr.querySelector('[data-action="clear-new-row"]');
     if (clearItem) { clearItem.disabled = false; clearItem.style.opacity = ''; clearItem.style.pointerEvents = ''; }
@@ -595,7 +602,7 @@ function createExistingProductRowHTML(id, productId, cantidad, supplierId) {
           ${productOptions.join('')}
         </select>
       </td>
-      <td><input type="number" name="quantity" min="1" class="input" style="width:70px;" placeholder="0" aria-label="Cantidad" value="${cantidad > 0 ? cantidad : ''}"></td>
+      <td><input type="number" name="quantity" min="1" class="input" placeholder="0" aria-label="Cantidad" value="${cantidad > 0 ? cantidad : ''}"></td>
       <td><span class="text-sm text-muted" id="ap-existing-unit-${id}">${escapeHtml(unitName)}</span></td>
       <td><select name="supplier" class="select-native" aria-label="Proveedor">${supplierOptions.join('')}</select></td>
       <td style="white-space:nowrap;">

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -953,6 +953,28 @@ td.td-num       { text-align: center; font-variant-numeric: tabular-nums; }
 .modal-add-product-dialog .input { width: 100%; min-width: 0; font-size: 13px; padding: 6px 8px; }
 .modal-add-product-dialog .input[type="number"] { text-align: right; }
 
+/* ── Tabla "Productos existentes" (5 columnas) ─────────────────────────────
+   .ap-existing-table-wrap distingue esta tabla de la de "Nuevos productos"
+   (9 columnas) que también usa .entry-table-wrap en el mismo modal.
+   Sin esta clase, las reglas nth-child de arriba contaminarían esta tabla. */
+.modal-add-product-dialog .ap-existing-table-wrap table { table-layout: fixed; width: 100%; }
+
+/* Producto 38% | Cantidad 12% | Unidad 13% | Proveedor 30% | Acciones 76px */
+.modal-add-product-dialog .ap-existing-table-wrap th:nth-child(1),
+.modal-add-product-dialog .ap-existing-table-wrap td:nth-child(1) { width: 38%; }
+
+.modal-add-product-dialog .ap-existing-table-wrap th:nth-child(2),
+.modal-add-product-dialog .ap-existing-table-wrap td:nth-child(2) { width: 12%; text-align: right; }
+
+.modal-add-product-dialog .ap-existing-table-wrap th:nth-child(3),
+.modal-add-product-dialog .ap-existing-table-wrap td:nth-child(3) { width: 13%; }
+
+.modal-add-product-dialog .ap-existing-table-wrap th:nth-child(4),
+.modal-add-product-dialog .ap-existing-table-wrap td:nth-child(4) { width: 30%; }
+
+.modal-add-product-dialog .ap-existing-table-wrap th:nth-child(5),
+.modal-add-product-dialog .ap-existing-table-wrap td:nth-child(5) { width: 76px; text-align: center; }
+
 /* Dashboard movement modals — prevent horizontal overflow from inline widths */
 #modal-entry .entry-table-wrap table,
 #modal-exit .table-wrapper table,

--- a/frontend/views/inventario.html
+++ b/frontend/views/inventario.html
@@ -336,7 +336,7 @@
           </button>
         </div>
         <div id="ap-section-existing-body">
-          <div class="table-wrapper entry-table-wrap" style="overflow-x:auto;">
+          <div class="table-wrapper entry-table-wrap ap-existing-table-wrap" style="overflow-x:auto;">
             <table>
               <thead>
                 <tr>
@@ -344,7 +344,7 @@
                   <th class="text-right">Cantidad</th>
                   <th class="text-left">Unidad</th>
                   <th class="text-left">Proveedor</th>
-                  <th style="width:80px;"></th>
+                  <th></th>
                 </tr>
               </thead>
               <tbody id="existing-product-rows"></tbody>


### PR DESCRIPTION

- Añadir clase ap-existing-table-wrap a la tabla de productos existentes para desambiguar selectores nth-child del CSS (antes las reglas de 9 columnas de 'Nuevos' contaminaban la tabla de 5 columnas 'Existentes')
- Agregar bloque CSS con table-layout:fixed y anchos 38/12/13/30%/76px para la tabla de productos existentes
- Eliminar inline styles width:80px del th y width:70px del input cantidad
- Disparar evento 'input' en addProductRow cuando el nombre viene pre-rellenado para que el debounce de verificación se ejecute automáticamente al mover una fila de Existentes a Nuevos (sin necesidad de editar el campo manualmente)